### PR TITLE
bugfix: task0 hided bug that crashes close

### DIFF
--- a/src/graphnode.cpp
+++ b/src/graphnode.cpp
@@ -11,7 +11,12 @@ GraphNode::~GraphNode()
     //// STUDENT CODE
     ////
 
-    delete _chatBot; 
+    //delete _chatBot; //TASK0. Bug: this delete _chatBot shouldn't be here. 
+                       // Problem: chatbot is deleted twice: 
+                       //  - once from chatlogic, which has created it using new --> this is correct
+                       //  - once here on GraphNode, which has become it as reference. --> therefore this is wrong
+                       // GraphNode does not creates a new  chatBot, it just references
+                       // one, therefore it should not delete it. 
 
     ////
     //// EOF STUDENT CODE


### PR DESCRIPTION
Task0: corrected memory leak bug that crashes application on close. Chatbot destrctor was called twice, once from chatlogic, creator of a chatbot instance (OK), and once from GraphNode, which references that chatbot instance but does not creates it (wrong).