### PR TITLE
feat: task4 moving smart pointers

### DIFF
--- a/src/graphnode.cpp
+++ b/src/graphnode.cpp
@@ -32,9 +32,18 @@ void GraphNode::AddEdgeToParentNode(GraphEdge *edge)
     _parentEdges.push_back(edge);
 }
 
-void GraphNode::AddEdgeToChildNode(GraphEdge *edge)
+//void GraphNode::AddEdgeToChildNode(GraphEdge *edge)
+/**
+ * NOTE: Grpahnode takes ownership of incomming edges 
+ * NOTICE: the unique_ptr is moved twice: 
+ *  - once from caller to function and 
+ *  - once inside the function to vector
+ *  for detailed answer see: AddEdgeToChildNode 
+ */
+void GraphNode::AddEdgeToChildNode(std::unique_ptr<GraphEdge> edge) //function takes ownoership of the object
 {
-    _childEdges.push_back(edge);
+    //_childEdges.push_back(edge);
+    _childEdges.emplace_back(std::move(edge));
 }
 
 //// STUDENT CODE
@@ -58,7 +67,7 @@ GraphEdge *GraphNode::GetChildEdgeAtIndex(int index)
     //// STUDENT CODE
     ////
 
-    return _childEdges[index];
+    return _childEdges[index].get();// return raw pointer to owned object(unique_ptr)
 
     ////
     //// EOF STUDENT CODE

--- a/src/graphnode.h
+++ b/src/graphnode.h
@@ -5,6 +5,7 @@
 #include <string>
 #include "chatbot.h"
 
+#include <memory>
 
 // forward declarations
 class GraphEdge;
@@ -16,7 +17,7 @@ private:
     ////
 
     // data handles (owned)
-    std::vector<GraphEdge *> _childEdges;  // edges to subsequent nodes
+    std::vector<std::unique_ptr<GraphEdge>> _childEdges;  // edges to subsequent nodes
 
     // data handles (not owned)
     std::vector<GraphEdge *> _parentEdges; // edges to preceding nodes 
@@ -44,7 +45,8 @@ public:
     // proprietary functions
     void AddToken(std::string token); // add answers to list
     void AddEdgeToParentNode(GraphEdge *edge);
-    void AddEdgeToChildNode(GraphEdge *edge);
+    //void AddEdgeToChildNode(GraphEdge *edge);
+    void AddEdgeToChildNode(std::unique_ptr<GraphEdge> edge); //Task4
 
     //// STUDENT CODE
     ////


### PR DESCRIPTION
Modified graphnode and chatlogic to make edge's smart_pointers (unique_ptr) and managed by Graphnode insteance. Now each Graphnode instance manage the incomming  edges (see AddEdgeToChildNode() function)